### PR TITLE
Add edit functionality for posts and videos 

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import Login from './pages/Login';
 import Home from './pages/Home';
 import Upload from './pages/Upload';
 import Explore from './pages/Explore';
+import EditVideo from './pages/EditVideo';
 import Friends from './pages/Friends';
 
 // Components
@@ -42,6 +43,7 @@ function AppContent() {
             <Route path="/" element={<Home />} />
             <Route path="/upload" element={<Upload />} />
             <Route path="/explore" element={<Explore />} />
+            <Route path="/edit-video" element={<EditVideo />} />
             <Route path="/friends" element={<Friends />} />
             <Route path="/posts" element={<AllPosts />} />
             <Route path="/create-post" element={<CreatePost />} />

--- a/client/src/components/AllPosts.jsx
+++ b/client/src/components/AllPosts.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import PostCard from './PostCard';
@@ -7,29 +8,34 @@ import { PlusCircle, Search, MessageSquare, Filter } from 'lucide-react';
 import { API } from '@/api';
 
 const AllPosts = () => {
+  const location = useLocation();
   const [posts, setPosts] = useState([]);
   const [filteredPosts, setFilteredPosts] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('All');
   const [categories, setCategories] = useState(['All']);
 
+  const fetchPosts = async () => {
+    try {
+      const res = await API.get('/posts');
+      const postsData = Array.isArray(res.data) ? res.data : [];
+      setPosts(postsData);
+      setFilteredPosts(postsData);
+      const uniqueCategories = ['All', ...new Set(postsData.map(post => post?.category).filter(Boolean))];
+      setCategories(uniqueCategories);
+    } catch (err) {
+      console.error('Failed to fetch posts:', err);
+    }
+  };
+
   useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        const res = await API.get('/posts');
-        const postsData = Array.isArray(res.data) ? res.data : [];
-        setPosts(postsData);
-        setFilteredPosts(postsData);
-
-        const uniqueCategories = ['All', ...new Set(postsData.map(post => post?.category).filter(Boolean))];
-        setCategories(uniqueCategories);
-      } catch (err) {
-        console.error('Failed to fetch posts:', err);
-      }
-    };
-
     fetchPosts();
   }, []);
+
+  // Refetch when we navigate back to this page (e.g. after edit) so list shows updated content
+  useEffect(() => {
+    if (location.pathname === '/posts') fetchPosts();
+  }, [location.pathname]);
 
   useEffect(() => {
     let filtered = posts;

--- a/client/src/components/CreatePost.jsx
+++ b/client/src/components/CreatePost.jsx
@@ -1,26 +1,39 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import  Textarea  from '@/components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { toast } from 'sonner';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { PenTool, Send } from 'lucide-react';
 import { API } from '@/api';
 import { getToken } from '@/utils/auth';
 
 const CreatePost = () => {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [category, setCategory] = useState('');
+  const location = useLocation();
+  const editPost = location.state?.editPost;
+
+  const [title, setTitle] = useState(editPost?.title ?? '');
+  const [content, setContent] = useState(editPost?.content ?? '');
+  const [category, setCategory] = useState(editPost?.category ?? '');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const navigate = useNavigate();
+
+  const isEditMode = Boolean(editPost?._id);
+
+  useEffect(() => {
+    if (editPost) {
+      setTitle(editPost.title ?? '');
+      setContent(editPost.content ?? '');
+      setCategory(editPost.category ?? '');
+    }
+  }, [editPost]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
 
     if (!title.trim() || !content.trim()) {
-      toast.error( "Please fill in all required fields");
+      toast.error("Please fill in all required fields");
       return;
     }
 
@@ -31,24 +44,28 @@ const CreatePost = () => {
       return;
     }
 
-
     try {
-      const res = await API.post('/posts', {
-        title,
-        content,
-        category: category || "General"
-      }, {
-        headers: {
-          Authorization: `Bearer ${getToken()}`
-        }
-      });
-
-      toast.success("Your post has been created successfully");
-
+      if (isEditMode) {
+        await API.put(`/posts/${editPost._id}`, {
+          title,
+          content,
+          category: category || "General"
+        });
+        toast.success("Post updated successfully");
+      } else {
+        await API.post('/posts', {
+          title,
+          content,
+          category: category || "General"
+        }, {
+          headers: { Authorization: `Bearer ${getToken()}` }
+        });
+        toast.success("Your post has been created successfully");
+      }
       navigate('/posts');
     } catch (error) {
-      console.error('Error creating post:', error);
-      toast.error("Failed to create post. Please try again.")
+      console.error('Error creating/updating post:', error);
+      toast.error(error.response?.data?.message || (isEditMode ? "Failed to update post." : "Failed to create post. Please try again."));
     } finally {
       setIsSubmitting(false);
     }
@@ -60,14 +77,14 @@ const CreatePost = () => {
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-800 mb-2 flex items-center gap-3">
             <PenTool className="h-8 w-8 text-green-600" />
-            Create New Post
+            {isEditMode ? 'Edit Post' : 'Create New Post'}
           </h1>
-          <p className="text-gray-600">Share your thoughts with the sports community</p>
+          <p className="text-gray-600">{isEditMode ? 'Update your post below' : 'Share your thoughts with the sports community'}</p>
         </div>
 
         <Card className="shadow-lg">
           <CardHeader>
-            <CardTitle className="text-xl text-blue-600">Write Your Post</CardTitle>
+            <CardTitle className="text-xl text-blue-600">{isEditMode ? 'Edit Your Post' : 'Write Your Post'}</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-6">
@@ -116,7 +133,7 @@ const CreatePost = () => {
                   className="bg-green-500 hover:bg-green-600 text-white flex items-center gap-2"
                 >
                   <Send className="h-4 w-4" />
-                  {isSubmitting ? 'Creating...' : 'Create Post'}
+                  {isSubmitting ? (isEditMode ? 'Saving...' : 'Creating...') : (isEditMode ? 'Save Changes' : 'Create Post')}
                 </Button>
                 <Button
                   type="button"

--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Heart, MessageCircle, Calendar, Tag, User, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Heart, MessageCircle, Calendar, Tag, User, Trash2, Pencil } from 'lucide-react';
 import CommentSection from './CommentSection';
 import { API } from '@/api';
 import { getToken, getUserId } from '@/utils/auth';
 import { toast } from 'sonner';
 
 const PostCard = ({ post, onDelete }) => {
+  const navigate = useNavigate();
   const [isLiked, setIsLiked] = useState(false);
   const [likes, setLikes] = useState(post.likes?.length || 0);
   const [showComments, setShowComments] = useState(false);
@@ -15,6 +17,10 @@ const PostCard = ({ post, onDelete }) => {
   const postId = post._id;
   const userId = getUserId();
   const postOwnerId = post.postedBy?._id || post.postedBy;
+
+  const handleEdit = () => {
+    navigate('/create-post', { state: { editPost: post } });
+  };
 
   const handleDelete = async () => {
     if (!window.confirm("Are you sure you want to delete this post?")) return;
@@ -106,15 +112,24 @@ const PostCard = ({ post, onDelete }) => {
             </div>
           </div>
 
-          {/* Delete Button - Fixed Positioning */}
+          {/* Edit & Delete - only for post owner */}
           {userId === postOwnerId && (
-            <button
-              onClick={handleDelete}
-              className="absolute top-4 right-4 p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-full transition-all duration-200"
-              title="Delete Post"
-            >
-              <Trash2 className="h-4 w-4" />
-            </button>
+            <div className="absolute top-4 right-4 flex items-center gap-1">
+              <button
+                onClick={handleEdit}
+                className="p-2 text-slate-500 hover:text-blue-400 hover:bg-blue-500/10 rounded-full transition-all duration-200"
+                title="Edit Post"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                onClick={handleDelete}
+                className="p-2 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded-full transition-all duration-200"
+                title="Delete Post"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
           )}
         </div>
       </CardHeader>

--- a/client/src/components/VideoCard.jsx
+++ b/client/src/components/VideoCard.jsx
@@ -3,13 +3,19 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import Badge from '@/components/ui/badge';
 import { toast } from 'sonner';
-import { Play, Calendar, User, Eye, Trash2 } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Play, Calendar, User, Eye, Trash2, Pencil } from 'lucide-react';
 import { API } from '@/api';
 import { getUserId, getToken } from '@/utils/auth';
 
 const VideoCard = ({ video, onPlay, onDelete }) => {
+  const navigate = useNavigate();
   const userId = getUserId();
   const videoOwnerId = video?.postedBy?._id || video?.postedBy;
+
+  const handleEdit = () => {
+    navigate('/edit-video', { state: { video } });
+  };
 
   const handleDelete = async () => {
     const id = video._id || video.id;
@@ -59,15 +65,24 @@ const VideoCard = ({ video, onPlay, onDelete }) => {
 
   return (
     <Card className="group bg-slate-900 border-slate-800 rounded-xl overflow-hidden hover:-translate-y-1 hover:border-slate-700 transition-all duration-200 relative">
-      {/* Delete Button */}
+      {/* Edit & Delete - only for video owner */}
       {videoOwnerId === userId && (
-        <button
-          onClick={handleDelete}
-          className="absolute top-3 right-3 z-10 p-2 rounded-lg bg-slate-800/80 text-slate-400 hover:text-red-400 hover:bg-red-500/20 transition-all duration-200"
-          title="Delete Video"
-        >
-          <Trash2 className="w-4 h-4" />
-        </button>
+        <div className="absolute top-3 right-3 z-10 flex items-center gap-1">
+          <button
+            onClick={handleEdit}
+            className="p-2 rounded-lg bg-slate-800/80 text-slate-400 hover:text-blue-400 hover:bg-blue-500/20 transition-all duration-200"
+            title="Edit Video"
+          >
+            <Pencil className="w-4 h-4" />
+          </button>
+          <button
+            onClick={handleDelete}
+            className="p-2 rounded-lg bg-slate-800/80 text-slate-400 hover:text-red-400 hover:bg-red-500/20 transition-all duration-200"
+            title="Delete Video"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
       )}
 
       {/* Thumbnail */}

--- a/client/src/pages/EditVideo.jsx
+++ b/client/src/pages/EditVideo.jsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import Textarea from '@/components/ui/textarea';
+import { toast } from 'sonner';
+import { API } from '@/api';
+import { getToken } from '@/utils/auth';
+
+const EditVideo = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const video = location.state?.video;
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (video) {
+      setTitle(video.title ?? '');
+      setDescription(video.description ?? '');
+      setCategory(video.category ?? '');
+    }
+  }, [video]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!video?._id) {
+      toast.error('Video not found');
+      navigate('/explore');
+      return;
+    }
+    if (!title.trim() || !category.trim()) {
+      toast.error('Title and category are required');
+      return;
+    }
+    if (!getToken()) {
+      toast.error('Please login first');
+      navigate('/login');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await API.put(`/videos/${video._id}`, {
+        title: title.trim(),
+        description: description.trim(),
+        category: category.trim(),
+      });
+      toast.success('Video updated successfully');
+      navigate('/explore');
+    } catch (err) {
+      toast.error(err.response?.data?.message || 'Failed to update video');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!video) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 flex items-center justify-center">
+        <p className="text-gray-600">No video to edit. <button type="button" onClick={() => navigate('/explore')} className="text-blue-600 underline">Go to Explore</button></p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-green-50 py-12">
+      <div className="max-w-2xl mx-auto px-4">
+        <h1 className="text-3xl font-bold text-gray-800 mb-2">Edit Video</h1>
+        <p className="text-gray-600 mb-8">Update title, description, and category.</p>
+        <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-lg border p-8 space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Title *</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-transparent bg-white text-gray-900 placeholder:text-gray-400"
+              placeholder="Video title"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Category *</label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-green-500 focus:border-transparent bg-white text-gray-900"
+              required
+            >
+              <option value="" className="text-gray-500">Select category</option>
+              <option value="UNHEARD STORIES" className="text-gray-900">Unheard Stories</option>
+              <option value="MATCH ANALYSIS" className="text-gray-900">Match Analysis</option>
+              <option value="SPORTS AROUND THE GLOBE" className="text-gray-900">Sports Around The Globe</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">Description (optional)</label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Description"
+              className="min-h-[120px] resize-none bg-white text-gray-900 placeholder:text-gray-400 border border-gray-300"
+            />
+          </div>
+          <div className="flex gap-4">
+            <Button type="submit" disabled={isSubmitting} className="bg-green-500 hover:bg-green-600 text-white">
+              {isSubmitting ? 'Saving...' : 'Save Changes'}
+            </Button>
+            <Button type="button" variant="outline" onClick={() => navigate('/explore')}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default EditVideo;

--- a/client/src/pages/Explore.jsx
+++ b/client/src/pages/Explore.jsx
@@ -1,14 +1,14 @@
 // Explore.jsx
 import React, { useState, useEffect } from 'react';
 import { Search } from 'lucide-react';
-import { useNavigate } from "react-router-dom";
-import Navbar from '@/components/Navbar';
+import { useNavigate, useLocation } from "react-router-dom";
 import VideoCard from '@/components/VideoCard';
 import CategoryFilter from '@/components/CategoryFilter';
 import VideoPlayer from '@/components/VideoPlayer';
 import { API } from '@/api';
 
 const Explore = () => {
+  const location = useLocation();
   const [videos, setVideos] = useState([]);
   const [filteredVideos, setFilteredVideos] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('ALL');
@@ -16,29 +16,31 @@ const Explore = () => {
   const [videoCounts, setVideoCounts] = useState({});
   const [selectedVideo, setSelectedVideo] = useState(null);
 
+  const fetchVideos = async () => {
+    try {
+      const res = await API.get('/videos');
+      const allVideos = Array.isArray(res.data) ? res.data : [];
+      setVideos(allVideos);
+      setFilteredVideos(allVideos);
+      const counts = {
+        ALL: allVideos.length,
+        'UNHEARD STORIES': allVideos.filter(v => v?.category === 'UNHEARD STORIES').length,
+        'MATCH ANALYSIS': allVideos.filter(v => v?.category === 'MATCH ANALYSIS').length,
+        'SPORTS AROUND THE GLOBE': allVideos.filter(v => v?.category === 'SPORTS AROUND THE GLOBE').length
+      };
+      setVideoCounts(counts);
+    } catch (error) {
+      console.error('Error fetching videos:', error);
+    }
+  };
+
   useEffect(() => {
-    const fetchVideos = async () => {
-      try {
-        const res = await API.get('/videos');
-        const allVideos = Array.isArray(res.data) ? res.data : [];
-
-        setVideos(allVideos);
-        setFilteredVideos(allVideos);
-
-        const counts = {
-          ALL: allVideos.length,
-          'UNHEARD STORIES': allVideos.filter(v => v?.category === 'UNHEARD STORIES').length,
-          'MATCH ANALYSIS': allVideos.filter(v => v?.category === 'MATCH ANALYSIS').length,
-          'SPORTS AROUND THE GLOBE': allVideos.filter(v => v?.category === 'SPORTS AROUND THE GLOBE').length
-        };
-        setVideoCounts(counts);
-      } catch (error) {
-        console.error('Error fetching videos:', error);
-      }
-    };
-
     fetchVideos();
   }, []);
+
+  useEffect(() => {
+    if (location.pathname === '/explore') fetchVideos();
+  }, [location.pathname]);
 
   useEffect(() => {
     let filtered = [...videos];

--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -1,10 +1,17 @@
 const express = require("express");
 const router = express.Router();
-const { createPost ,getAllPosts, likePost,deletePost} = require("../controllers/postController");
+const { createPost, getAllPosts, likePost, deletePost, updatePost } = require("../controllers/postController");
 const { verifyToken } = require("../middleware/auth");
-router.post("/posts",verifyToken,createPost);
-router.get("/posts",getAllPosts);
-router.post("/posts/:id/like",verifyToken,likePost)
-router.delete("/posts/:postId",verifyToken,deletePost)
+
+// Create & read posts
+router.post("/posts", verifyToken, createPost);
+router.get("/posts", getAllPosts);
+
+// Interactions
+router.post("/posts/:id/like", verifyToken, likePost);
+
+// Update & delete (owner only)
+router.put("/posts/:postId", verifyToken, updatePost);
+router.delete("/posts/:postId", verifyToken, deletePost);
 
 module.exports = router

--- a/server/routes/video.js
+++ b/server/routes/video.js
@@ -1,11 +1,15 @@
 const express = require("express");
 const router = express.Router();
-const { createVideo ,getAllVideos,deleteVideo} = require("../controllers/videoController");
+const { createVideo, getAllVideos, deleteVideo, updateVideo } = require("../controllers/videoController");
 const { verifyToken } = require("../middleware/auth");
 const upload = require("../middleware/multer"); // required to handle video uploads
 
+// Create & read videos
 router.post("/video/upload", verifyToken, upload.single("video"), createVideo);
-router.get("/videos",getAllVideos);
+router.get("/videos", getAllVideos);
+
+// Update & delete (owner only)
+router.put("/videos/:id", verifyToken, updateVideo);
 router.delete("/videos/:id", verifyToken, deleteVideo);
 
 module.exports = router


### PR DESCRIPTION
What I changed
Edit Post
Added a PUT /api/posts/:postId endpoint on the backend, with a strict owner check so only the post author can edit.
Added an Edit (pencil) button on PostCard, shown only to the post owner.
Refactored the CreatePost component to support both create and edit modes:
When editing, the form is pre‑filled with the existing title, content and category.
On submit, it calls PUT /posts/:id instead of creating a new post.
After saving, the posts list refreshes automatically so updated content appears without a full page reload.
Edit Video
Added a PUT /api/videos/:id endpoint on the backend, again with an owner check.
Added an Edit (pencil) button on VideoCard, visible only for the video owner.
Created a new EditVideo page (/edit-video) where the user can update the video’s title, description and category (the actual file is unchanged).
Updated Explore so that when you return after editing, it refetches the videos and shows the latest data.
UX / Styling
Improved the Edit Video form’s input, select and textarea styles:
Switched to a light background with dark text for better readability.
Kept placeholders a lighter grey so typed text stands out clearly.

https://github.com/user-attachments/assets/c0bf118e-cabc-411f-a84e-7f81f4de8247

#24 
