### PR TITLE
Add Copy link button on video and post cards

### DIFF
--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -3,11 +3,11 @@ import { motion } from 'framer-motion';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
-import { Heart, MessageCircle, Calendar, Tag, User, Trash2, Pencil, Share2, ArrowBigUp, ArrowBigDown, Pin, MoreHorizontal } from 'lucide-react';
+import { Heart, MessageCircle, Calendar, Tag, User, Trash2, Pencil, Share2, Link2, ArrowBigUp, ArrowBigDown, Pin, MoreHorizontal } from 'lucide-react';
 import CommentSection from './CommentSection';
 import { API } from '@/api';
 import { getToken, getUserId } from '@/utils/auth';
-import { getShareUrl, shareLink } from '@/utils/share';
+import { getShareUrl, shareLink, copyLinkToClipboard } from '@/utils/share';
 import { toast } from 'sonner';
 
 const PostCard = ({ post, onDelete, isPinned = false }) => {
@@ -31,6 +31,16 @@ const PostCard = ({ post, onDelete, isPinned = false }) => {
       url,
       post.title || 'Post on HuddleUp',
       post.content?.slice(0, 100) || '',
+      (msg) => toast.success(msg),
+      (msg) => toast.error(msg)
+    );
+  };
+
+  const handleCopyLink = (e) => {
+    e?.stopPropagation?.();
+    const url = getShareUrl('post', postId);
+    copyLinkToClipboard(
+      url,
       (msg) => toast.success(msg),
       (msg) => toast.error(msg)
     );
@@ -260,6 +270,18 @@ const PostCard = ({ post, onDelete, isPinned = false }) => {
             >
               <MessageCircle className="w-4 h-4" />
               <span>Comments</span>
+            </button>
+
+            <button
+              onClick={handleCopyLink}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg transition-all text-sm font-medium"
+              style={{ color: 'var(--text-sub)' }}
+              onMouseEnter={(e) => e.currentTarget.style.background = 'var(--bg-elevated)'}
+              onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+              title="Copy link"
+            >
+              <Link2 className="w-4 h-4" />
+              <span>Copy link</span>
             </button>
 
             <button

--- a/client/src/components/VideoCard.jsx
+++ b/client/src/components/VideoCard.jsx
@@ -4,10 +4,10 @@ import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import Badge from '@/components/ui/badge';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
-import { Play, Calendar, User, Eye, Trash2, Pencil, Share2, Clock } from 'lucide-react';
+import { Play, Calendar, User, Eye, Trash2, Pencil, Share2, Link2, Clock } from 'lucide-react';
 import { API } from '@/api';
 import { getUserId, getToken } from '@/utils/auth';
-import { getShareUrl, shareLink } from '@/utils/share';
+import { getShareUrl, shareLink, copyLinkToClipboard } from '@/utils/share';
 
 const VideoCard = ({ video, onPlay, onDelete }) => {
   const navigate = useNavigate();
@@ -26,6 +26,17 @@ const VideoCard = ({ video, onPlay, onDelete }) => {
       url,
       video.title || 'Video on HuddleUp',
       video.description?.slice(0, 100) || '',
+      (msg) => toast.success(msg),
+      (msg) => toast.error(msg)
+    );
+  };
+
+  const handleCopyLink = (e) => {
+    e.stopPropagation();
+    if (!videoId) return;
+    const url = getShareUrl('video', videoId);
+    copyLinkToClipboard(
+      url,
       (msg) => toast.success(msg),
       (msg) => toast.error(msg)
     );
@@ -291,6 +302,26 @@ const VideoCard = ({ video, onPlay, onDelete }) => {
             Watch
           </button>
           
+          <button
+            onClick={handleCopyLink}
+            className="p-2 rounded-lg transition-all"
+            style={{
+              border: '1px solid var(--border-subtle)',
+              color: 'var(--text-sub)'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = 'var(--accent)';
+              e.currentTarget.style.color = 'var(--accent)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = 'var(--border-subtle)';
+              e.currentTarget.style.color = 'var(--text-sub)';
+            }}
+            title="Copy link"
+          >
+            <Link2 className="w-4 h-4" />
+          </button>
+
           <button
             onClick={(e) => {
               e.stopPropagation();

--- a/client/src/pages/Explore.jsx
+++ b/client/src/pages/Explore.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate,useLocation, useSearchParams } from "react-router-dom";
+import { useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { motion } from 'framer-motion';
 import PageWrapper from '@/components/ui/PageWrapper';
-import { TrendingUp, Clock, Flame, Globe, ChevronRight, Search, Play, User } from 'lucide-react';
+import { TrendingUp, Clock, Flame, Globe, ChevronRight, Search, Play, User, Link2 } from 'lucide-react';
 import VideoPlayer from '@/components/VideoPlayer';
 import { API } from '@/api';
+import { toast } from 'sonner';
+import { getShareUrl, copyLinkToClipboard } from '@/utils/share';
 
 const Explore = () => {
   const navigate = useNavigate();
@@ -54,6 +56,18 @@ const Explore = () => {
 
   const handleClosePlayer = () => {
     setSelectedVideo(null);
+  };
+
+  const handleCopyLink = (e, video) => {
+    e.stopPropagation();
+    const videoId = video._id || video.id;
+    if (!videoId) return;
+    const url = getShareUrl('video', videoId);
+    copyLinkToClipboard(
+      url,
+      (msg) => toast.success(msg),
+      (msg) => toast.error(msg)
+    );
   };
 
   // Category counts
@@ -366,6 +380,20 @@ const Explore = () => {
                       </span>
                     </div>
                   )}
+
+                  {/* Copy link - top right */}
+                  <button
+                    onClick={(e) => handleCopyLink(e, video)}
+                    className="absolute top-3 right-3 z-10 p-2 rounded-lg transition-opacity hover:opacity-100 opacity-90"
+                    style={{
+                      background: 'rgba(0,0,0,0.6)',
+                      color: 'white',
+                      border: '1px solid rgba(255,255,255,0.2)'
+                    }}
+                    title="Copy link"
+                  >
+                    <Link2 className="w-4 h-4" />
+                  </button>
 
                   {/* Content */}
                   <div className="absolute bottom-0 left-0 right-0 p-4">

--- a/client/src/utils/share.js
+++ b/client/src/utils/share.js
@@ -12,6 +12,33 @@ export function getShareUrl(type, id) {
 }
 
 /**
+ * Copy URL to clipboard and show success/error via callbacks.
+ * @param {string} url - full URL to copy
+ * @param {(msg: string) => void} onSuccess - e.g. toast.success('Link copied!')
+ * @param {(msg: string) => void} onError - e.g. toast.error
+ */
+export async function copyLinkToClipboard(url, onSuccess, onError) {
+  try {
+    await navigator.clipboard.writeText(url);
+    onSuccess?.('Link copied!');
+  } catch (err) {
+    const textarea = document.createElement('textarea');
+    textarea.value = url;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      onSuccess?.('Link copied!');
+    } catch (e) {
+      onError?.('Could not copy link');
+    }
+    document.body.removeChild(textarea);
+  }
+}
+
+/**
  * Share content: use Web Share API if available, else copy link to clipboard.
  * @param {string} url - full URL to share
  * @param {string} title - title for share dialog


### PR DESCRIPTION
 A "Copy link" action on every video and post card so users can share content by copying the page URL to the clipboard, with a short success toast.
Changes
1. client/src/utils/share.js
Added copyLinkToClipboard(url, onSuccess, onError) helper that:
Copies the given URL to the clipboard using navigator.clipboard.writeText
Falls back to document.execCommand('copy') when Clipboard API is not available
Calls onSuccess('Link copied!') or onError(...) for toast/feedback
2. client/src/components/VideoCard.jsx
Imported copyLinkToClipboard and Link2 icon
Added Copy link button (Link2 icon) next to the existing Share button in the action bar
On click: copies the video share URL and shows "Link copied!" toast; click does not trigger card open (stopPropagation)
3. client/src/components/PostCard.jsx
Imported copyLinkToClipboard and Link2 icon
Added Copy link button (icon + "Copy link" text) next to the Share button in the thread actions bar
On click: copies the post share URL and shows "Link copied!" toast
4. client/src/pages/Explore.jsx
Explore page does not use VideoCard; it renders video cards inline. So Copy link was missing on Explore.
Imported toast, getShareUrl, copyLinkToClipboard, and Link2
Added handleCopyLink(e, video) to copy the video URL and show toast (with e.stopPropagation() so the card does not open the player)
Added a Copy link button (Link2 icon) on each Explore grid card (top-right), always visible so it works on mobile too
How to test
Explore: Open Explore, hover/tap any video card → top-right Copy link (link icon) → click → "Link copied!" toast; paste somewhere to confirm URL.
VideoCard (wherever used): Use the link icon next to Watch → same behavior.
PostCard: Use "Copy link" next to Share → same behavior.
<img width="1227" height="817" alt="Screenshot 2026-02-17 143345" src="https://github.com/user-attachments/assets/8308f2a0-69b5-4c22-ad7b-961e6d753b03" />

Closes #95