### PR TITLE
Add close/cancel for toggles and toasts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -82,7 +82,7 @@ export default function App() {
       <NotificationProvider>
         <AppContent />
       </NotificationProvider>
-      <Toaster richColors position="top-center" />
+      <Toaster richColors position="top-center" closeButton />
     </Router>
   );
 }

--- a/client/src/components/CommentList.jsx
+++ b/client/src/components/CommentList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Reply, Trash2, ArrowBigUp, ArrowBigDown, MessageCircle, MoreVertical, Award } from 'lucide-react';
 import { API } from '@/api';
@@ -13,6 +13,16 @@ function CommentItem({ comment, onAddComment, onDeleteComment, level = 0, isOP =
   const [voteState, setVoteState] = useState(null); // 'up', 'down', or null
   const [score, setScore] = useState((comment.upvotes || 0) - (comment.downvotes || 0));
   const [showOptions, setShowOptions] = useState(false);
+  const optionsRef = useRef(null);
+
+  useEffect(() => {
+    if (!showOptions) return;
+    const handleClickOutside = (e) => {
+      if (optionsRef.current && !optionsRef.current.contains(e.target)) setShowOptions(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showOptions]);
 
   const handleDelete = async () => {
     const token = getToken();
@@ -207,7 +217,7 @@ function CommentItem({ comment, onAddComment, onDeleteComment, level = 0, isOP =
         </div>
 
         {/* Options Menu */}
-        <div className="relative">
+        <div className="relative" ref={optionsRef}>
           <button
             onClick={() => setShowOptions(!showOptions)}
             className="p-1 rounded transition-opacity opacity-0 group-hover:opacity-100"

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -112,6 +112,13 @@ export default function Navbar() {
               <>
                 {/* Notification Bell */}
                 <div className="relative">
+                  {showNotifications && (
+                    <div
+                      className="fixed inset-0 z-[99]"
+                      aria-hidden
+                      onClick={() => setShowNotifications(false)}
+                    />
+                  )}
                   <button
                     onClick={() => {
                       setShowNotifications(!showNotifications);
@@ -177,7 +184,13 @@ export default function Navbar() {
 
       {/* Mobile Menu */}
       {open && (
-        <div className="md:hidden border-t border-white/10 bg-zinc-950/95 backdrop-blur-xl">
+        <>
+          <div
+            className="fixed inset-0 z-40 md:hidden"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
+          <div className="md:hidden border-t border-white/10 bg-zinc-950/95 backdrop-blur-xl relative z-50">
           <div className="px-6 py-4 space-y-4">
             {links.map(({ to, label }) => (
               <NavLink
@@ -226,6 +239,7 @@ export default function Navbar() {
             </div>
           </div>
         </div>
+        </>
       )}
     </motion.nav>
   );

--- a/client/src/components/NotificationDropdown.jsx
+++ b/client/src/components/NotificationDropdown.jsx
@@ -58,11 +58,21 @@ export default function NotificationDropdown({
           <h3 className="text-sm font-extrabold text-zinc-900 dark:text-zinc-100 uppercase tracking-widest">
             Inbox
           </h3>
-          {totalNew > 0 && (
-            <span className="px-2.5 py-1 rounded-full bg-emerald-500 text-white text-[10px] font-black uppercase">
-              {totalNew} New
-            </span>
-          )}
+          <div className="flex items-center gap-2">
+            {totalNew > 0 && (
+              <span className="px-2.5 py-1 rounded-full bg-emerald-500 text-white text-[10px] font-black uppercase">
+                {totalNew} New
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="p-1.5 rounded-lg text-zinc-500 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
+              aria-label="Close"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
         {/* Content */}

--- a/client/src/components/VideoPlayer.jsx
+++ b/client/src/components/VideoPlayer.jsx
@@ -101,12 +101,14 @@ const VideoPlayer = ({ video, onClose }) => {
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/90 backdrop-blur-sm p-4 md:p-10"
+        onClick={(e) => e.target === e.currentTarget && onClose()}
       >
         <motion.div
           initial={{ scale: 0.9, y: 20 }}
           animate={{ scale: 1, y: 0 }}
           exit={{ scale: 0.9, y: 20 }}
           className="relative w-full max-w-6xl h-full max-h-[90vh] bg-white dark:bg-zinc-900 rounded-[32px] shadow-2xl flex flex-col md:flex-row overflow-hidden border border-zinc-200 dark:border-zinc-800"
+          onClick={(e) => e.stopPropagation()}
         >
           {/* Left Side: Video Content */}
           <div className="flex-[1.5] flex flex-col bg-black relative">


### PR DESCRIPTION
Description:
Toggles & dropdowns 
Notification bell dropdown: click outside (backdrop) or header X to close.
Video player modal: click on backdrop to close.
Mobile nav menu: tap/click outside to close.
Comment “more” options menu: click outside to close.
Toasts
Toaster now shows a close (X) button on every toast so users can dismiss messages like “Link copied!” or “Login successful!” without waiting for auto-dismiss.
<img width="1205" height="730" alt="Screenshot 2026-02-20 151154" src="https://github.com/user-attachments/assets/9d96dd86-eabf-461b-b4a5-3de773f0864d" />
closes #112 
