### PR TITLE
Use React Router Link in Footer for SPA navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -76,7 +76,7 @@ function AppContent() {
             <Route path="/contributors" element={<Contributor />} />
             <Route path="/terms" element={<TermsOfService />} />
             <Route path="/community-guidelines" element={<CommunityGuidelines />} />
-            <Route path="/Feedback" element={<Feedback />} />
+            <Route path="/feedback" element={<Feedback />} />
             <Route path="/admin" element={<Admin />} />
             <Route path="/live-match" element={<LiveMatchRooms />} />
           </Routes>

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { FaInstagram, FaTwitter, FaGithub, FaLinkedin } from 'react-icons/fa';
 
 export default function Footer() {
@@ -41,13 +42,13 @@ export default function Footer() {
                 { href: "/about", label: "About" }
               ].map((link) => (
                 <li key={link.label} className="group">
-                  <a
-                    href={link.href}
+                  <Link
+                    to={link.href}
                     className="text-sm text-zinc-400 hover:text-emerald-400 inline-flex items-center gap-2 transition-all duration-200"
                   >
                     <span className="w-1.5 h-1.5 rounded-full bg-pink-500 opacity-0 group-hover:opacity-100 transition-opacity"></span>
                     {link.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>
@@ -67,13 +68,13 @@ export default function Footer() {
               { href: "/community-guidelines", label: "Community Guidelines", id: "community-guidelines" }
               ].map((link) => (
                 <li key={link.id} className="group">
-                  <a
-                    href={link.href}
+                  <Link
+                    to={link.href}
                     className="text-sm text-zinc-400 hover:text-emerald-400 inline-flex items-center gap-2 transition-all duration-200"
                   >
                     <span className="w-1.5 h-1.5 rounded-full bg-pink-500 opacity-0 group-hover:opacity-100 transition-opacity"></span>
                     {link.label}
-                  </a>
+                  </Link>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION

### Summary
Footer navigation now uses React Router’s `Link` for internal routes so navigation is client-side and no longer causes full page reloads.

### Changes
- **Footer (`client/src/components/Footer.jsx`)**  
  - Replaced `<a href="...">` with `<Link to="...">` for:
    - **Quick Links:** Home (`/`), Explore (`/explore`), Upload (`/upload`), Discussion (`/posts`), About (`/about`)
    - **Resources:** Contact (`/contact`), Feedback (`/feedback`), Privacy Policy (`/privacy-policy`), Terms of Service (`/terms`), Community Guidelines (`/community-guidelines`)
  - Left external links (social: Instagram, Twitter, GitHub, LinkedIn) and the mailto email link as `<a>` tags with `target="_blank"` and `rel="noopener noreferrer"` where appropriate.
- **App routing (`client/src/App.jsx`)**  
  - Updated Feedback route from `/Feedback` to `/feedback` so it matches the footer link and routing convention.

### Testing
- Click each Quick Link and Resource link and confirm in-app navigation without full reload.
- Confirm social and email links still open in a new tab or mail client as before.

Closes #157 
