### PR TITLE
Add API rate limiting to protect backend endpoints

### DIFF
--- a/server/middleware/rateLimit.js
+++ b/server/middleware/rateLimit.js
@@ -8,6 +8,10 @@ try {
     RedisStore = null;
 }
 
+/**
+ * Creates a Redis store for rate limiting
+ * Falls back to memory store if Redis is not available
+ */
 const createStore = (prefix) => {
     if (RedisStore && isRedisReady()) {
         return new RedisStore({
@@ -18,31 +22,234 @@ const createStore = (prefix) => {
     return undefined;
 };
 
+/**
+ * Extract user ID from request for user-based rate limiting
+ */
+const getUserId = (req) => {
+    if (req.user?.id) {
+        return `user_${req.user.id}`;
+    }
+    return null;
+};
+
+/**
+ * General API limiter - 100 requests per 15 minutes
+ * Applied to most API routes
+ */
 const apiLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 100,
     standardHeaders: true,
     legacyHeaders: false,
     store: createStore("api"),
-    message: { message: "Too many requests, please try again later." },
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many requests, please try again later." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Rate limit exceeded. Please try again later.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
 });
 
+/**
+ * Strict auth limiter - 15 requests per 15 minutes
+ * Applied to login, registration, and password reset endpoints
+ */
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 15,
     standardHeaders: true,
     legacyHeaders: false,
     store: createStore("auth"),
-    message: { message: "Too many login attempts, please try again later." },
+    message: { status: 429, message: "Too many authentication attempts, please try again later." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Too many authentication attempts. Please try again after 15 minutes.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
 });
 
+/**
+ * Feed limiter - 60 requests per minute
+ * Applied to feed endpoints
+ */
 const feedLimiter = rateLimit({
     windowMs: 60 * 1000,
     max: 60,
     standardHeaders: true,
     legacyHeaders: false,
     store: createStore("feed"),
-    message: { message: "Too many feed requests, please slow down." },
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many feed requests, please slow down." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Rate limit exceeded on feed. Please slow down.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
 });
 
-module.exports = { apiLimiter, authLimiter, feedLimiter };
+/**
+ * Video upload limiter - 5 uploads per 24 hours
+ * Applied to video upload endpoints
+ */
+const videoUploadLimiter = rateLimit({
+    windowMs: 24 * 60 * 60 * 1000,
+    max: 5,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("video_upload"),
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many video uploads, please try again later." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Daily video upload limit exceeded. Please try again tomorrow.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+/**
+ * Search limiter - 30 requests per minute
+ * Applied to search endpoints
+ */
+const searchLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("search"),
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many search requests." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Too many search requests. Please wait before searching again.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+/**
+ * Comment limiter - 30 comments per 15 minutes
+ * Prevents spam in comments
+ */
+const commentLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("comment"),
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many comments, please slow down." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Comment rate limit exceeded. Please slow down.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+/**
+ * Post creation limiter - 10 posts per 24 hours
+ * Prevents spam posts
+ */
+const postCreationLimiter = rateLimit({
+    windowMs: 24 * 60 * 60 * 1000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("post_creation"),
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many posts created, please try again later." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Daily post creation limit exceeded.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+/**
+ * Password reset limiter - 3 requests per hour
+ * Prevents brute force password reset attempts
+ */
+const passwordResetLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 3,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("password_reset"),
+    message: { status: 429, message: "Too many password reset attempts." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Too many password reset attempts. Please try again in 1 hour.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+/**
+ * Admin operations limiter - 50 requests per hour
+ * Applied to admin endpoints
+ */
+const adminLimiter = rateLimit({
+    windowMs: 60 * 60 * 1000,
+    max: 50,
+    standardHeaders: true,
+    legacyHeaders: false,
+    store: createStore("admin"),
+    keyGenerator: (req) => {
+        return getUserId(req) || req.ip;
+    },
+    message: { status: 429, message: "Too many admin operations." },
+    skip: (req) => false,
+    handler: (req, res) => {
+        res.status(429).json({
+            status: 429,
+            message: "Admin operation rate limit exceeded.",
+            retryAfter: req.rateLimit.resetTime
+        });
+    }
+});
+
+module.exports = {
+    apiLimiter,
+    authLimiter,
+    feedLimiter,
+    videoUploadLimiter,
+    searchLimiter,
+    commentLimiter,
+    postCreationLimiter,
+    passwordResetLimiter,
+    adminLimiter
+};

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -4,11 +4,12 @@ const authController = require("../controllers/authController")
 const { register, login, getUserProfile, updateUserProfile, updatePassword, forgotPassword, resetPassword } = require('../controllers/authController');
 const { verifyToken } = require("../middleware/auth");
 const { registerValidator, loginValidator, profileUpdateValidator, passwordUpdateValidator } = require("../middleware/validation");
+const { passwordResetLimiter } = require("../middleware/rateLimit");
 
 router.post("/register", registerValidator, register);
 router.post("/login", loginValidator, login);
-router.post("/forgot-password", forgotPassword);
-router.post("/reset-password", resetPassword);
+router.post("/forgot-password", passwordResetLimiter, forgotPassword);
+router.post("/reset-password", passwordResetLimiter, resetPassword);
 router.get("/profile", verifyToken, getUserProfile);
 router.put("/profile", verifyToken, profileUpdateValidator, updateUserProfile);
 router.put("/password", verifyToken, passwordUpdateValidator, updatePassword);

--- a/server/routes/comment.js
+++ b/server/routes/comment.js
@@ -3,8 +3,9 @@ const router = express.Router();
 const {createComment,getAllComments,getAllPostComments, deleteComment,likeVideo, viewVideo, getSingleVideo,toggleLikeComment} = require("../controllers/commentController");
 const { verifyToken} = require("../middleware/auth");
 const { commentValidator } = require("../middleware/validation");
+const { commentLimiter } = require("../middleware/rateLimit");
 
-router.post("/comments", verifyToken, commentValidator, createComment);
+router.post("/comments", verifyToken, commentLimiter, commentValidator, createComment);
 router.get("/comments/:videoId",getAllComments);
 router.get("/comments/post/:postId", getAllPostComments);
 router.delete("/comments/:commentId", verifyToken, deleteComment);

--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -3,9 +3,10 @@ const router = express.Router();
 const { createPost, getAllPosts, likePost, deletePost, updatePost } = require("../controllers/postController");
 const { verifyToken } = require("../middleware/auth");
 const { postValidator } = require("../middleware/validation");
+const { postCreationLimiter } = require("../middleware/rateLimit");
 
 // Create & read posts
-router.post("/posts", verifyToken, postValidator, createPost);
+router.post("/posts", verifyToken, postCreationLimiter, postValidator, createPost);
 router.get("/posts", getAllPosts);
 
 // Interactions

--- a/server/routes/video.js
+++ b/server/routes/video.js
@@ -10,8 +10,9 @@ const {
 const { verifyToken } = require("../middleware/auth");
 const { videoValidator } = require("../middleware/validation");
 const upload = require("../middleware/multer");
+const { videoUploadLimiter } = require("../middleware/rateLimit");
 
-router.post("/video/upload", verifyToken, upload.single("video"), videoValidator, createVideo);
+router.post("/video/upload", verifyToken, videoUploadLimiter, upload.single("video"), videoValidator, createVideo);
 router.get("/videos", getAllVideos);
 router.get("/videos/:id/status", getProcessingStatus);
 router.put("/videos/:id", verifyToken, videoValidator, updateVideo);

--- a/server/server.js
+++ b/server/server.js
@@ -6,7 +6,17 @@ const dotenv = require("dotenv")
 const cors = require("cors")
 const path = require('path');
 const { initRedis } = require("./config/redis");
-const { apiLimiter, authLimiter } = require("./middleware/rateLimit");
+const { 
+  apiLimiter, 
+  authLimiter, 
+  feedLimiter,
+  videoUploadLimiter,
+  searchLimiter,
+  commentLimiter,
+  postCreationLimiter,
+  passwordResetLimiter,
+  adminLimiter
+} = require("./middleware/rateLimit");
 const { videoQueue } = require("./services/videoQueue");
 const authRoutes = require("./routes/auth")
 const videoRoutes = require("./routes/video")
@@ -72,8 +82,8 @@ app.use("/api", apiLimiter, friendRoutes)
 app.use("/api", apiLimiter, userRoutes)
 app.use("/api", apiLimiter, savedRoutes)
 app.use("/api/notifications", apiLimiter, notificationRoutes);
-app.use("/api/admin", apiLimiter, adminRoutes);
-app.use("/api/feed", feedRoutes);
+app.use("/api/admin", adminLimiter, adminRoutes);
+app.use("/api/feed", feedLimiter, feedRoutes);
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 app.get("/api", (req, res) => {


### PR DESCRIPTION
 Adds rate limiting to all API endpoints to prevent abuse, spam, and DDoS attacks.

## Changes
- Created 9 rate limiters for different endpoint types (auth, videos, posts, comments, feed, etc.)
- Tracks authenticated users by ID and unauthenticated requests by IP
- Uses Redis for distributed rate limiting
- Returns HTTP 429 with retry information when limits exceeded

## Rate Limits
- General API: 100 requests/15 min
- Auth: 15 requests/15 min
- Feed: 60 requests/min
- Video upload: 5/day
- Comments: 30/15 min
- Posts: 10/day
- Password reset: 3/hour
- Admin: 50/hour


closes: #170
@vedhapprakashni  plz review it
