### PR TITLE
Add Contributors link to Footer Resources

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -63,9 +63,8 @@ export default function Footer() {
                 { href: "/feedback", label: "Feedback", id: "feedback" },
                 { href: "/privacy-policy", label: "Privacy Policy", id: "privacy-main" },
                 { href: "/terms", label: "Terms of Service", id: "terms-main" },
-                // { href: "#", label: "Privacy Policy", id: "privacy-secondary" },
-                // { href: "#", label: "Terms of Service", id: "terms-secondary" },
-              { href: "/community-guidelines", label: "Community Guidelines", id: "community-guidelines" }
+                { href: "/contributors", label: "Contributors", id: "contributors" },
+                { href: "/community-guidelines", label: "Community Guidelines", id: "community-guidelines" }
               ].map((link) => (
                 <li key={link.id} className="group">
                   <Link


### PR DESCRIPTION
Description:
Adds a "Contributors" link under the footer’s Resources section so users can reach the existing /contributors page from the footer.
Added a new item in the Resources list in Footer.jsx using React Router <Link to="/contributors">.
Placed alongside Contact, Feedback, Privacy Policy, Terms of Service, and Community Guidelines.
Closes #167
