### PR TITLE
fixed real time updates

### DIFF
--- a/client/src/components/CommentSection.jsx
+++ b/client/src/components/CommentSection.jsx
@@ -3,6 +3,7 @@ import CommentInput from './CommentInput';
 import CommentList from './CommentList';
 import { API } from '@/api';
 import { MessageCircle, TrendingUp, Users } from 'lucide-react';
+import { socket } from '@/lib/socket';
 
 export default function CommentSection({ contentId, contentType }) {
   const [comments, setComments] = useState([]);
@@ -30,17 +31,29 @@ export default function CommentSection({ contentId, contentType }) {
   }, [contentId, contentType]);
 
   const addComment = (newComment) => {
-    if (newComment.parentId) {
-      const addReply = (list) =>
-        list.map((comment) =>
-          comment._id === newComment.parentId
-            ? { ...comment, replies: [...(comment.replies || []), newComment] }
-            : { ...comment, replies: comment.replies ? addReply(comment.replies) : [] }
-        );
-      setComments((prev) => addReply(prev));
-    } else {
-      setComments((prev) => [newComment, ...prev]);
-    }
+    setComments((prev) => {
+      const existsInTree = (list) => {
+        for (const c of list) {
+          if (c._id === newComment._id) return true;
+          if (c.replies && c.replies.length && existsInTree(c.replies)) return true;
+        }
+        return false;
+      };
+
+      if (existsInTree(prev)) return prev;
+
+      if (newComment.parentId) {
+        const addReply = (list) =>
+          list.map((comment) =>
+            comment._id === newComment.parentId
+              ? { ...comment, replies: [...(comment.replies || []), newComment] }
+              : { ...comment, replies: comment.replies ? addReply(comment.replies) : [] }
+          );
+        return addReply(prev);
+      }
+
+      return [newComment, ...prev];
+    });
   };
 
   const handleDeleteComment = (commentId) => {
@@ -53,6 +66,42 @@ export default function CommentSection({ contentId, contentType }) {
         }));
     setComments((prev) => removeComment(prev));
   };
+
+  useEffect(() => {
+    if (!contentId || !contentType) return;
+
+    socket.connect();
+
+    const roomPayload = { contentId, contentType };
+    socket.emit('join_content', roomPayload);
+
+    const handleNewComment = (payload) => {
+      if (
+        payload.contentId !== contentId ||
+        payload.contentType !== contentType
+      ) {
+        return;
+      }
+      if (payload.comment) {
+        addComment(payload.comment);
+      }
+    };
+
+    const handleDeletedComment = (payload) => {
+      const targetId = payload.commentId;
+      if (!targetId) return;
+      handleDeleteComment(targetId);
+    };
+
+    socket.on('comment:new', handleNewComment);
+    socket.on('comment:deleted', handleDeletedComment);
+
+    return () => {
+      socket.emit('leave_content', roomPayload);
+      socket.off('comment:new', handleNewComment);
+      socket.off('comment:deleted', handleDeletedComment);
+    };
+  }, [contentId, contentType]);
 
   return (
     <div className="space-y-8">

--- a/client/src/components/PostCard.jsx
+++ b/client/src/components/PostCard.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -10,6 +10,7 @@ import { API } from '@/api';
 import { getToken, getUserId } from '@/utils/auth';
 import { getShareUrl, shareLink, copyLinkToClipboard } from '@/utils/share';
 import { toast } from 'sonner';
+import { socket } from '@/lib/socket';
 
 const PostCard = ({ post, onDelete, isPinned = false, isSaved = false, onSaveToggle }) => {
   const navigate = useNavigate();
@@ -102,6 +103,34 @@ const PostCard = ({ post, onDelete, isPinned = false, isSaved = false, onSaveTog
   };
 
   const categoryStyle = post.category ? getCategoryColor(post.category) : null;
+
+  useEffect(() => {
+    if (!postId) return;
+
+    socket.connect();
+
+    const roomPayload = { contentId: postId, contentType: 'post' };
+    socket.emit('join_content', roomPayload);
+
+    const handleLikeUpdate = (payload) => {
+      if (
+        payload.contentType !== 'post' ||
+        payload.contentId !== postId
+      ) {
+        return;
+      }
+      if (typeof payload.likes === 'number') {
+        setLikes(payload.likes);
+      }
+    };
+
+    socket.on('content:like_toggled', handleLikeUpdate);
+
+    return () => {
+      socket.emit('leave_content', roomPayload);
+      socket.off('content:like_toggled', handleLikeUpdate);
+    };
+  }, [postId]);
 
   return (
     <motion.div

--- a/client/src/components/VideoPlayer.jsx
+++ b/client/src/components/VideoPlayer.jsx
@@ -7,6 +7,7 @@ import { getAssetUrl } from '@/utils/url';
 import { Button } from './ui/button';
 import { toast } from 'sonner';
 import { motion, AnimatePresence } from 'framer-motion';
+import { socket } from '@/lib/socket';
 
 const VideoPlayer = ({ video, onClose }) => {
   const videoRef = useRef(null);
@@ -48,6 +49,34 @@ const VideoPlayer = ({ video, onClose }) => {
       setHasViewed(true);
     }
   }, [isPlaying, hasViewed, videoId]);
+
+  useEffect(() => {
+    if (!videoId) return;
+
+    socket.connect();
+
+    const roomPayload = { contentId: videoId, contentType: 'video' };
+    socket.emit('join_content', roomPayload);
+
+    const handleLikeUpdate = (payload) => {
+      if (
+        payload.contentType !== 'video' ||
+        payload.contentId !== videoId
+      ) {
+        return;
+      }
+      if (typeof payload.likes === 'number') {
+        setLikes(payload.likes);
+      }
+    };
+
+    socket.on('content:like_toggled', handleLikeUpdate);
+
+    return () => {
+      socket.emit('leave_content', roomPayload);
+      socket.off('content:like_toggled', handleLikeUpdate);
+    };
+  }, [videoId]);
 
   // Close modal on Escape key (#156)
   useEffect(() => {

--- a/server/controllers/commentController.js
+++ b/server/controllers/commentController.js
@@ -7,6 +7,7 @@ const Notification = require("../models/Notification");
 const { trackLike, trackView, trackComment } = require("./analyticsController");
 const { getNestedComments } = require("../services/optimizedCommentService");
 const { invalidateQueryCache } = require("../utils/queryCache");
+const { emitToContentRoom } = require("../socketRegistry");
 
 async function createCommentNotification({ recipientId, senderId, type, resource, message }) {
   if (!recipientId || recipientId.toString() === senderId.toString()) return;
@@ -122,17 +123,32 @@ exports.createComment = async (req, res) => {
       }
     }
 
-    res.status(201).json({
+    const responseComment = {
       _id: saved._id,
-      author: saved.userId?.username || 'Anonymous',
+      author: saved.userId?.username || "Anonymous",
       content: saved.text,
       createdAt: saved.createdAt,
       parentId: saved.parentId,
       replies: [],
       likes: saved.likes || [],
       videoId: saved.videoId,
-      postId: saved.postId
-    });
+      postId: saved.postId,
+    };
+
+    const contentIdForSocket =
+      (commentData.videoId || commentData.postId || "").toString();
+
+    if (contentIdForSocket) {
+      emitToContentRoom("comment:new", {
+        comment: responseComment,
+        contentId: contentIdForSocket,
+        contentType: commentData.videoId ? "video" : "post",
+        videoId: commentData.videoId ? contentIdForSocket : null,
+        postId: commentData.postId ? contentIdForSocket : null,
+      });
+    }
+
+    res.status(201).json(responseComment);
   } catch (err) {
     console.error("🔥 Error creating comment:", err);
     res.status(500).json({ message: "Error creating comment", error: err.message });
@@ -189,6 +205,15 @@ exports.likeVideo = async (req, res) => {
 
     trackLike(id, userId, !isLiked).catch(() => {});
 
+    emitToContentRoom("content:like_toggled", {
+      contentId: id,
+      contentType: "video",
+      likes: updatedVideo.likes.length,
+      liked: !isLiked,
+      videoId: id,
+      postId: null,
+    });
+
     res.json({ likes: updatedVideo.likes.length, liked: !isLiked });
   } catch (err) {
     res.status(500).json({ message: "Error liking video", error: err.message });
@@ -242,6 +267,8 @@ exports.deleteComment = async (req, res) => {
       return res.status(403).json({ message: "Unauthorized - You can only delete your own comments" });
     }
 
+    const { videoId, postId } = comment;
+
     await Comment.findByIdAndDelete(commentId);
     
     await invalidateQueryCache([
@@ -249,6 +276,14 @@ exports.deleteComment = async (req, res) => {
       `comments:stats:*`,
       `comments:top:*`,
     ]);
+
+    if (videoId || postId) {
+      emitToContentRoom("comment:deleted", {
+        commentId,
+        videoId: videoId ? videoId.toString() : null,
+        postId: postId ? postId.toString() : null,
+      });
+    }
 
     res.status(200).json({ message: "Comment deleted successfully" });
   } catch (err) {

--- a/server/controllers/postController.js
+++ b/server/controllers/postController.js
@@ -3,6 +3,7 @@ const User = require("../models/User");
 const Notification = require("../models/Notification");
 const { deleteCachePattern } = require("../utils/cache");
 const { invalidateQueryCache } = require("../utils/queryCache");
+const { emitToContentRoom } = require("../socketRegistry");
 
 exports.createPost = async (req, res) => {
   try {
@@ -74,6 +75,16 @@ exports.likePost = async (req, res) => {
     }
 
     await deleteCachePattern("feed:*");
+
+    emitToContentRoom("content:like_toggled", {
+      contentId: postId,
+      contentType: "post",
+      likes: updatedPost.likes.length,
+      liked: !isLiked,
+      videoId: null,
+      postId,
+    });
+
     res.status(200).json({
       likedByUser: !isLiked,
       likesCount: updatedPost.likes.length,

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ const dotenv = require("dotenv")
 const cors = require("cors")
 const path = require('path');
 const { initRedis } = require("./config/redis");
+const { setIO, getContentRoom } = require("./socketRegistry");
 const { initQueryMonitoring, queryPerformanceMiddleware } = require("./middleware/queryMonitor");
 const { 
   apiLimiter, 
@@ -48,6 +49,8 @@ const io = new Server(server, {
   }
 });
 
+setIO(io);
+
 io.on("connection", (socket) => {
   socket.on("join_match", (matchId) => {
     socket.join(`match_${matchId}`);
@@ -55,6 +58,26 @@ io.on("connection", (socket) => {
 
   socket.on("send_message", ({ matchId, user, text }) => {
     io.to(`match_${matchId}`).emit("receive_message", { user, text });
+  });
+
+  socket.on("join_content", ({ contentType, contentId }) => {
+    const room = getContentRoom({
+      videoId: contentType === "video" ? contentId : null,
+      postId: contentType === "post" ? contentId : null,
+    });
+    if (room) {
+      socket.join(room);
+    }
+  });
+
+  socket.on("leave_content", ({ contentType, contentId }) => {
+    const room = getContentRoom({
+      videoId: contentType === "video" ? contentId : null,
+      postId: contentType === "post" ? contentId : null,
+    });
+    if (room) {
+      socket.leave(room);
+    }
   });
 
   socket.on("join_feed", () => {

--- a/server/socketRegistry.js
+++ b/server/socketRegistry.js
@@ -1,0 +1,34 @@
+let ioInstance = null;
+
+const setIO = (io) => {
+  ioInstance = io;
+};
+
+const getIO = () => ioInstance;
+
+const getContentRoom = ({ videoId, postId }) => {
+  if (videoId) return `video_${videoId}`;
+  if (postId) return `post_${postId}`;
+  return null;
+};
+
+const emitToContentRoom = (event, payload) => {
+  if (!ioInstance) return;
+
+  const room = getContentRoom({
+    videoId: payload.videoId,
+    postId: payload.postId,
+  });
+
+  if (!room) return;
+
+  ioInstance.to(room).emit(event, payload);
+};
+
+module.exports = {
+  setIO,
+  getIO,
+  getContentRoom,
+  emitToContentRoom,
+};
+


### PR DESCRIPTION
# 🏟️ HuddleUp — Pull Request

## 📋 Description
Implemented real-time updates for comments, replies, and likes using Socket.io with content-based rooms per video/post. Clients viewing the same video or post now automatically receive live comment, reply, delete, and like updates, with optimistic UI behavior preserved for the acting user

## 🔗 Related Issue
<!-- Link the issue this PR addresses (e.g., "Fixes #123" or "Closes #123") -->
Fixes #197 

## 📝 Type of Change
<!-- Mark the appropriate option with an "x" (e.g., [x]) -->

- [ ] ✨ **New Feature** - Adding new functionality (e.g., video reactions, friend system, notifications)
- [ ] 🐛 **Bug Fix** - Non-breaking fix for an issue
- [x] 🔧 **Enhancement** - Improvement to existing functionality
- [ ] 🎨 **UI/UX** - Styling, layout, or responsiveness improvements
- [ ] 📚 **Documentation** - Updates to README, CONTRIBUTING, or inline docs
- [ ] ♻️ **Refactor** - Code restructuring without changing behavior
- [ ] 🔒 **Security** - Auth, JWT, or data protection improvements

## 🏗️ Area of Change
<!-- Mark all that apply -->

- [x] `client/` — React frontend (components, pages, hooks, context)
- [x] `server/` — Express backend (controllers, routes, middleware, models)
- [ ] Both frontend and backend
- [ ] Config / CI / Docs only

| Feature            | Before                                                                 | After                                                                                                  |
|--------------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
| Comments / Replies | Loaded via REST only; users had to refresh to see new comments/replies | New comments, replies, and deletions are broadcast via Socket.io per-content room in real time        |
| Likes (Videos/Posts) | Like count updated only for the user who clicked; others needed refresh | Like toggles emit `content:like_toggled` to the relevant room; all viewers see live count updates     |
| Rooms              | Socket.io used only for live match chat rooms                           | Added `join_content` / `leave_content` with `video_<id>` / `post_<id>` content-specific rooms         |

## Testing
Opened the same video in two browsers:
Posted a top-level comment and a reply → both appeared instantly in the other browser.
Deleted a comment → removal propagated live to the other browser.
Toggled video like → like count updated in both browsers without refresh.