### PR TITLE
fix: move UserSchema.index() before module.exports to ensure text ind…

### DIFF
--- a/server/models/User.js
+++ b/server/models/User.js
@@ -72,6 +72,7 @@ const UserSchema = new mongoose.Schema({
     resetPasswordExpires: { type: Date },
 }, { timestamps: true })
 
-module.exports = mongoose.model("User", UserSchema)
-
+// Text index must be defined before model compilation
 UserSchema.index({ username: "text", bio: "text" });
+
+module.exports = mongoose.model("User", UserSchema)


### PR DESCRIPTION
## Fix: Move `UserSchema.index()` Before `module.exports` (#209)

### Summary
The text search index on `username` and `bio` was defined **after** `mongoose.model()` compiled the schema, causing the index to be silently ignored. This broke `$text` search queries and caused full collection scans.

### Changes
- Moved `UserSchema.index({ username: "text", bio: "text" })` to **before** `module.exports = mongoose.model("User", UserSchema)`
- Added clarifying comment explaining why index must precede model compilation

### Files Changed
- [server/models/User.js](file:///d:/Open-Source-Projects/HuddleUp/server/models/User.js)

### Before
```js
module.exports = mongoose.model("User", UserSchema)

UserSchema.index({ username: "text", bio: "text" });  // ❌ Too late — model already compiled
```

### After
```js
// Text index must be defined before model compilation
UserSchema.index({ username: "text", bio: "text" });

module.exports = mongoose.model("User", UserSchema)  // ✅ Index registered correctly
```

### Testing
- No new dependencies
- Existing `$text` search queries on users will now work reliably
- After deployment, verify index exists: `db.users.getIndexes()` should show a `text` index on `username` and `bio`

### Related
Closes #209