### PR TITLE
fix(#210): re-apply content filter on post edit

### DIFF
--- a/server/__tests__/postController.test.js
+++ b/server/__tests__/postController.test.js
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for updatePost content-filter re-application (Issue #210)
+ */
+
+// ── Mocks ──────────────────────────────────────────────────
+const mockSave = jest.fn();
+const mockPopulate = jest.fn();
+const mockPostFindById = jest.fn();
+const mockReportCreate = jest.fn();
+
+jest.mock("../models/Post", () => ({
+    findById: (...args) => mockPostFindById(...args),
+}));
+
+jest.mock("../models/Report", () => ({
+    create: (...args) => mockReportCreate(...args),
+}));
+
+jest.mock("../models/User", () => ({}));
+jest.mock("../models/Notification", () => ({}));
+jest.mock("../utils/cache", () => ({
+    deleteCachePattern: jest.fn().mockResolvedValue(),
+}));
+jest.mock("../socketEmitter", () => ({ emitFeedEvent: jest.fn() }));
+jest.mock("../utils/queryCache", () => ({
+    invalidateQueryCache: jest.fn().mockResolvedValue(),
+}));
+jest.mock("../socketRegistry", () => ({ emitToContentRoom: jest.fn() }));
+jest.mock("../utils/logger", () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+}));
+
+const { updatePost } = require("../controllers/postController");
+
+// ── Helpers ────────────────────────────────────────────────
+const USER_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+const buildReq = (postId, body) => ({
+    params: { postId },
+    user: { id: USER_ID },
+    body,
+});
+
+const buildRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+};
+
+const buildPost = (overrides = {}) => {
+    const post = {
+        _id: "bbbbbbbbbbbbbbbbbbbbbbbb",
+        title: "Original Title",
+        content: "Original Content",
+        category: "general",
+        postedBy: { toString: () => USER_ID },
+        flagged: false,
+        flagReason: "",
+        save: mockSave,
+        populate: mockPopulate,
+        ...overrides,
+    };
+    mockSave.mockResolvedValue(post);
+    mockPopulate.mockResolvedValue(post);
+    return post;
+};
+
+// ── Tests ──────────────────────────────────────────────────
+describe("updatePost – content filter re-application", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockReportCreate.mockResolvedValue({});
+    });
+
+    test("clean edit → flagged stays false, no Report created", async () => {
+        const post = buildPost();
+        mockPostFindById.mockResolvedValue(post);
+
+        const req = buildReq(post._id, { title: "Nice Title", content: "Good content here" });
+        const res = buildRes();
+
+        await updatePost(req, res);
+
+        expect(post.flagged).toBe(false);
+        expect(post.flagReason).toBe("");
+        expect(mockReportCreate).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test("harmful edit → post flagged, Report auto-created", async () => {
+        const post = buildPost();
+        mockPostFindById.mockResolvedValue(post);
+
+        const req = buildReq(post._id, {
+            title: "fuck this",
+            content: "some shit content",
+        });
+        const res = buildRes();
+
+        await updatePost(req, res);
+
+        expect(post.flagged).toBe(true);
+        expect(post.flagReason).toContain("Profanity");
+        expect(mockReportCreate).toHaveBeenCalledTimes(1);
+        expect(mockReportCreate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                contentType: "post",
+                contentId: post._id,
+                reason: "spam",
+                status: "pending",
+                description: expect.stringContaining("Auto-flagged on edit"),
+            })
+        );
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test("previously flagged post edited clean → flag cleared", async () => {
+        const post = buildPost({
+            flagged: true,
+            flagReason: "old issue",
+        });
+        mockPostFindById.mockResolvedValue(post);
+
+        const req = buildReq(post._id, {
+            title: "Nice Title",
+            content: "Totally clean content now",
+        });
+        const res = buildRes();
+
+        await updatePost(req, res);
+
+        expect(post.flagged).toBe(false);
+        expect(post.flagReason).toBe("");
+        expect(mockReportCreate).not.toHaveBeenCalled();
+        expect(res.status).toHaveBeenCalledWith(200);
+    });
+});

--- a/server/controllers/postController.js
+++ b/server/controllers/postController.js
@@ -184,6 +184,26 @@ exports.updatePost = async (req, res) => {
     if (typeof content === "string") post.content = content;
     if (typeof category === "string") post.category = category;
 
+    // Re-run content filter on the updated fields
+    const filterResult = filterMultipleFields({ title: post.title, content: post.content });
+    post.flagged = filterResult.flagged;
+    post.flagReason = filterResult.flagged ? filterResult.reasons.join('; ') : '';
+
+    // Auto-create report if content is flagged
+    if (filterResult.flagged) {
+      await Report.create({
+        reportedBy: req.user.id,
+        contentType: 'post',
+        contentId: post._id,
+        reason: 'spam',
+        description: `Auto-flagged on edit: ${filterResult.reasons.join('; ')}`,
+        status: 'pending',
+        priority: filterResult.severity === 'high' ? 'high' : 'medium',
+        contentSnapshot: { title: post.title, content: post.content, author: req.user.id }
+      });
+      logger.warn(`Post ${post._id} flagged on edit: ${filterResult.reasons.join('; ')}`);
+    }
+
     const updatedPost = await post.save();
     const populatedPost = await updatedPost.populate("postedBy", "username");
     await Promise.all([

--- a/server/package.json
+++ b/server/package.json
@@ -33,7 +33,10 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "testMatch": ["**/tests/**/*.test.js"],
+    "testMatch": [
+      "**/tests/**/*.test.js",
+      "**/__tests__/**/*.test.js"
+    ],
     "forceExit": true,
     "detectOpenHandles": true
   }


### PR DESCRIPTION
## fix(#210): Re-apply content filter on post edit

Closes #210

### Problem
[updatePost](cci:1://file:///d:/Open-Source-Projects/HuddleUp/server/controllers/postController.js:162:0-221:1) did not run the content filter, allowing users to bypass moderation by editing a previously approved post with harmful content.

### Changes
- Re-run [filterMultipleFields({ title, content })](cci:1://file:///d:/Open-Source-Projects/HuddleUp/server/services/contentFilterService.js:163:0-196:2) in [updatePost](cci:1://file:///d:/Open-Source-Projects/HuddleUp/server/controllers/postController.js:162:0-221:1) after field assignment
- Update `flagged` / `flagReason` based on filter result
- Auto-create a `Report` if edited content is flagged (mirrors [createPost](cci:1://file:///d:/Open-Source-Projects/HuddleUp/server/controllers/postController.js:12:0-52:1))
- Clear flag if previously flagged content is cleaned up
- Add 3 unit tests covering clean edit, harmful edit, and flag-clearing scenarios
- Fix `testMatch` in [package.json](cci:7://file:///d:/Open-Source-Projects/HuddleUp/server/package.json:0:0-0:0) to include `__tests__/` directory

### Testing
- 3 new tests in [server/__tests__/postController.test.js](cci:7://file:///d:/Open-Source-Projects/HuddleUp/server/__tests__/postController.test.js:0:0-0:0) — all passing
- 36/36 total tests pass
